### PR TITLE
Fix nan errors when compiling the codes with Node V12

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -251,7 +251,7 @@ public:
       Nan::New((uint32_t)len),
     };
 
-    onData->Call(2, arguments);
+    Nan::Call(onData->GetFunction(), Nan::GetCurrentContext()->Global(), 2, arguments);
   }
 private:
   Nan::Callback *onData;

--- a/src/macros.h
+++ b/src/macros.h
@@ -22,7 +22,7 @@
 #define CDATA_OR_NULL(name, var) \
   char *var = NULL; \
   if (name->IsObject()) { \
-    Local<Object> buf = name->ToObject(); \
+    Local<Object> buf = name->ToObject(Nan::GetCurrentContext()).ToLocalChecked(); \
     var = CDATA(buf); \
   }
 
@@ -31,42 +31,42 @@
     Nan::ThrowError(#var " must be a number"); \
     return; \
   } \
-  uint8_t var = name->IntegerValue();
+  uint8_t var = name->NumberValue(Nan::GetCurrentContext()).FromJust();
 
 #define ASSERT_UINT16(name, var) \
   if (!name->IsNumber()) { \
     Nan::ThrowError(#var " must be a number"); \
     return; \
   } \
-  uint16_t var = name->IntegerValue();
+  uint16_t var = name->NumberValue(Nan::GetCurrentContext()).FromJust();
 
 #define ASSERT_UINT(name, var) \
   if (!name->IsNumber()) { \
     Nan::ThrowError(#var " must be a number"); \
     return; \
   } \
-  uint32_t var = name->IntegerValue();
+  uint32_t var = name->NumberValue(Nan::GetCurrentContext()).FromJust();
 
 #define ASSERT_INT(name, var) \
   if (!name->IsNumber()) { \
     Nan::ThrowError(#var " must be a number"); \
     return; \
   } \
-  int var = name->IntegerValue();
+  int var = name->NumberValue(Nan::GetCurrentContext()).FromJust();
 
 #define ASSERT_OBJECT(name, var) \
   if (!name->IsObject()) { \
     Nan::ThrowError(#var " must be an object"); \
     return; \
   } \
-  Local<Object> var = name->ToObject();
+  Local<Object> var = name->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
 
 #define ASSERT_DEV(name, var) \
   if (!name->IsObject()) { \
     Nan::ThrowError(#var " must be an object"); \
     return; \
   } \
-  Local<Object> jsdev = name->ToObject(); \
+  Local<Object> jsdev = name->ToObject(Nan::GetCurrentContext()).ToLocalChecked(); \
   rtlsdr_dev_t *var = (struct rtlsdr_dev *)RTLSDRDevice::Resolve(jsdev);
 
 #define ASSERT_BUFFER(name, var) \
@@ -74,7 +74,7 @@
     Nan::ThrowError(#var " must be a buffer"); \
     return; \
   } \
-  Local<Object> var = name->ToObject();
+  Local<Object> var = name->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
 
 #define ASSERT_STRING(name, var) \
   if (!name->IsObject()) { \


### PR DESCRIPTION
Looks like `IntegerValue()` is deprecated. Use `NumberValue(Nan::GetCurrentContext()).FromJust()` instead.

```
../src/binding.cc:18:3: error: too few arguments to function call, single argument 'context' was not specified
  ASSERT_UINT(info[0], index)
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/macros.h:48:37: note: expanded from macro 'ASSERT_UINT'
  uint32_t var = name->IntegerValue();
                 ~~~~~~~~~~~~~~~~~~ ^
```

Related issue: https://github.com/bcoin-org/bcrypto/issues/7